### PR TITLE
Expand functionality of `autocomplete` resolver to support universal search

### DIFF
--- a/src/types/AutocompleteResult.ts
+++ b/src/types/AutocompleteResult.ts
@@ -18,4 +18,7 @@ export class AutocompleteResult {
 
   @Field(() => String)
   id: String;
+  
+  @Field(() => String)
+  eventId: String;
 }


### PR DESCRIPTION
Adds a new (optional, default false) `universal` arg to the autocomplete query to enable universal search across all sessions.

It also now returns eventId of the result to make further fetching results easier.
I also included `issueUrl` as a search parameter for projects to make that more convenient.

