### PR TITLE
Feature: Standup and Prosper Bot Automation

### DIFF
--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -16,10 +16,9 @@ import { makeDebug } from "../../utils";
 
 const DEBUG = makeDebug("activities:tasks:createStandup");
 const STANDUP_USER = "U026ZCTG0CB";
-const ADMIN_USER = "U024H3101";
 
 const DEFAULT_STANDUP = {
-  admins: [ADMIN_USER],
+  admins: ["U024H3101", "U07ACCWHDSA"],
   days: ["Monday", "Wednesday", "Friday"],
   time: "20:00:00",
   reminders: [{ time: "10:00:00" }, { time: "18:00:00" }],

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -16,11 +16,13 @@ import { makeDebug } from "../../utils";
 
 const DEBUG = makeDebug("activities:tasks:createStandup");
 const STANDUP_USER = "U026ZCTG0CB";
+const ADMIN_USER = "U024H3101";
+
 const DEFAULT_STANDUP = {
-  type: "SLACK",
+  admins: [ADMIN_USER],
   days: ["Monday", "Wednesday", "Friday"],
-  time: "10:00:00",
-  reportTime: "12:00:00",
+  time: "20:00:00",
+  reminders: [{ time: "10:00:00" }, { time: "18:00:00" }],
   timezone: "America/Los_Angeles",
   schedule: { type: "WEEKLY" },
   questions: [
@@ -30,10 +32,10 @@ const DEFAULT_STANDUP = {
   ],
   groupBy: "USER_SINGLE_MESSAGE",
   reportSortOrder: "DISPLAY_NAME",
-  allowEditsAfterCompletion: true,
+  allowEditsAfterCompletion: "EXTENDED",
   asThread: false,
   syncWithChannel: false,
-  hideAnnouncements: false,
+  hideAnnouncements: true,
 };
 
 export default async function createStandup({ auth }: Context): Promise<void> {

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -1,0 +1,97 @@
+import { PrismaClient } from "@prisma/client";
+import Container from "typedi";
+import { Context } from '../../context';
+import {
+  SlackEventWithProjects,
+  SlackMentorInfo,
+  SlackStudentInfo,
+  slackEventInfoSelect,
+} from "../../slack";
+import { makeDebug } from "../../utils";
+
+const DEBUG = makeDebug('activities:tasks:createStandup');
+
+const STANDUP_API_BASE = 'https://api.standup-and-prosper.com/v1';
+const EXCLUDED_SLACK_IDS = new Set(['U07ACCWHDSA']);
+
+const DEFAULT_STANDUP = {
+  type: 'SLACK',
+  days: ['Monday', 'Wednesday', 'Friday'],
+  time: '10:00:00',
+  reportTime: '12:00:00',
+  timezone: 'America/Los_Angeles',
+  schedule: { type: 'WEEKLY' },
+  questions: [
+    { text: 'What did you do since last standup?' },
+    { text: 'What will you do until next standup?' },
+    { text: 'Is anything blocking you?' },
+  ],
+  groupBy: 'USER_SINGLE_MESSAGE',
+  reportSortOrder: 'DISPLAY_NAME',
+  allowEditsAfterCompletion: true,
+  asThread: false,
+  syncWithChannel: false,
+  hideAnnouncements: false,
+};
+
+export default async function createStandup({ auth }: Context): Promise<void> {
+  const apiKey = process.env.STANDUP_API_KEY;
+  if (!apiKey) throw new Error('STANDUP_API_KEY environment variable is not set');
+
+  const prisma = Container.get(PrismaClient);
+  const events = await prisma.event.findMany({
+    where: {
+      id: auth.eventId,
+      slackWorkspaceAccessToken: { not: null },
+      slackWorkspaceId: { not: null },
+    },
+    select: slackEventInfoSelect,
+  }) as SlackEventWithProjects<SlackMentorInfo & SlackStudentInfo>[];
+
+  for (const event of events) {
+    const teamId = event.slackWorkspaceId;
+
+    for (const project of event.projects) {
+      if (!project.slackChannelId) {
+        DEBUG(`Skipping project ${project.id} — no Slack channel`);
+        continue;
+      }
+
+      const users = project.students
+        .filter((s) => s.slackId && !EXCLUDED_SLACK_IDS.has(s.slackId))
+        .map((s) => ({ userId: s.slackId! }));
+
+      if (users.length === 0) {
+        DEBUG(`Skipping project ${project.id} — no eligible student Slack IDs`);
+        continue;
+      }
+
+      const body = {
+        ...DEFAULT_STANDUP,
+        channel: project.slackChannelId,
+        channelId: project.slackChannelId,
+        users,
+      };
+
+      try {
+        const res = await fetch(`${STANDUP_API_BASE}/teams/${teamId}/standups`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+          const text = await res.text();
+          DEBUG(`Failed for project ${project.id}: ${res.status} ${text}`);
+        } else {
+          DEBUG(`Created standup for project ${project.id} in channel ${project.slackChannelId}`);
+        }
+      } catch (ex) {
+        DEBUG(ex);
+      }
+    }
+  }
+}

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -7,11 +7,10 @@ import {
   SlackStudentInfo,
   slackEventInfoSelect,
 } from "../../slack";
+import { EventWithStandupAndProsper, getClientForEvent } from "../../standupAndProsper/StandupAndProsper";
 import { makeDebug } from "../../utils";
 
 const DEBUG = makeDebug('activities:tasks:createStandup');
-
-const STANDUP_API_BASE = 'https://api.standup-and-prosper.com/v1';
 
 const DEFAULT_STANDUP = {
   type: 'SLACK',
@@ -34,9 +33,6 @@ const DEFAULT_STANDUP = {
 };
 
 export default async function createStandup({ auth }: Context): Promise<void> {
-  const apiKey = process.env.STANDUP_API_KEY;
-  if (!apiKey) throw new Error('STANDUP_API_KEY environment variable is not set');
-
   const prisma = Container.get(PrismaClient);
 
   const existing = await prisma.project.findMany({
@@ -50,12 +46,13 @@ export default async function createStandup({ auth }: Context): Promise<void> {
       id: auth.eventId,
       slackWorkspaceAccessToken: { not: null },
       slackWorkspaceId: { not: null },
+      standupAndProsperToken: { not: null },
     },
-    select: slackEventInfoSelect,
-  }) as SlackEventWithProjects<SlackMentorInfo & SlackStudentInfo>[];
+    select: { ...slackEventInfoSelect, standupAndProsperToken: true },
+  }) as (SlackEventWithProjects<SlackMentorInfo & SlackStudentInfo> & EventWithStandupAndProsper)[];
 
   for (const event of events) {
-    const teamId = event.slackWorkspaceId;
+    const client = getClientForEvent(event);
 
     for (const project of event.projects) {
       if (existingStandupIds.has(project.id)) {
@@ -85,28 +82,14 @@ export default async function createStandup({ auth }: Context): Promise<void> {
       };
 
       try {
-        const res = await fetch(`${STANDUP_API_BASE}/teams/${teamId}/standups`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(body),
-        });
-
-        if (!res.ok) {
-          const text = await res.text();
-          DEBUG(`Failed for project ${project.id}: ${res.status} ${text}`);
-        } else {
-          const data = await res.json() as { id?: string };
-          if (data.id) {
-            await prisma.project.update({
-              where: { id: project.id },
-              data: { standupId: data.id },
-            });
-          }
-          DEBUG(`Created standup for project ${project.id} in channel ${project.slackChannelId}`);
+        const result = await client.createStandup(body);
+        if (result.standupId) {
+          await prisma.project.update({
+            where: { id: project.id },
+            data: { standupId: result.standupId },
+          });
         }
+        DEBUG(`Created standup for project ${project.id} in channel ${project.slackChannelId}`);
       } catch (ex) {
         DEBUG(ex);
       }

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -1,31 +1,35 @@
 import { PrismaClient } from "@prisma/client";
 import Container from "typedi";
-import { Context } from '../../context';
+import { Context } from "../../context";
 import {
   SlackEventWithProjects,
   SlackMentorInfo,
   SlackStudentInfo,
+  getSlackClientForEvent,
   slackEventInfoSelect,
 } from "../../slack";
-import { EventWithStandupAndProsper, getClientForEvent } from "../../standupAndProsper/StandupAndProsper";
+import {
+  EventWithStandupAndProsper,
+  getClientForEvent,
+} from "../../standupAndProsper/StandupAndProsper";
 import { makeDebug } from "../../utils";
 
-const DEBUG = makeDebug('activities:tasks:createStandup');
-
+const DEBUG = makeDebug("activities:tasks:createStandup");
+const STANDUP_USER = "U026ZCTG0CB";
 const DEFAULT_STANDUP = {
-  type: 'SLACK',
-  days: ['Monday', 'Wednesday', 'Friday'],
-  time: '10:00:00',
-  reportTime: '12:00:00',
-  timezone: 'America/Los_Angeles',
-  schedule: { type: 'WEEKLY' },
+  type: "SLACK",
+  days: ["Monday", "Wednesday", "Friday"],
+  time: "10:00:00",
+  reportTime: "12:00:00",
+  timezone: "America/Los_Angeles",
+  schedule: { type: "WEEKLY" },
   questions: [
-    { text: 'What did you do since last standup?' },
-    { text: 'What will you do until next standup?' },
-    { text: 'Is anything blocking you?' },
+    { text: "What did you do since last standup?" },
+    { text: "What will you do until next standup?" },
+    { text: "Is anything blocking you?" },
   ],
-  groupBy: 'USER_SINGLE_MESSAGE',
-  reportSortOrder: 'DISPLAY_NAME',
+  groupBy: "USER_SINGLE_MESSAGE",
+  reportSortOrder: "DISPLAY_NAME",
   allowEditsAfterCompletion: true,
   asThread: false,
   syncWithChannel: false,
@@ -35,64 +39,73 @@ const DEFAULT_STANDUP = {
 export default async function createStandup({ auth }: Context): Promise<void> {
   const prisma = Container.get(PrismaClient);
 
-  const existing = await prisma.project.findMany({
-    where: { event: { id: auth.eventId }, standupId: { not: null } },
-    select: { id: true },
-  });
-  const existingStandupIds = new Set(existing.map((p: { id: string }) => p.id));
-
-  const events = await prisma.event.findMany({
+  const event = (await prisma.event.findFirst({
+    rejectOnNotFound: true,
     where: {
       id: auth.eventId,
       slackWorkspaceAccessToken: { not: null },
       slackWorkspaceId: { not: null },
       standupAndProsperToken: { not: null },
     },
-    select: { ...slackEventInfoSelect, standupAndProsperToken: true },
-  }) as (SlackEventWithProjects<SlackMentorInfo & SlackStudentInfo> & EventWithStandupAndProsper)[];
+    select: {
+      ...slackEventInfoSelect,
+      projects: {
+        ...slackEventInfoSelect.projects,
+        where: {
+          ...slackEventInfoSelect.projects.where,
+          standupId: null,
+          slackChannelId: { not: null },
+          students: {
+            some: {
+              slackId: { not: null },
+            },
+          },
+        },
+      },
+      standupAndProsperToken: true,
+    },
+  })) as SlackEventWithProjects<SlackMentorInfo & SlackStudentInfo> &
+    EventWithStandupAndProsper;
 
-  for (const event of events) {
-    const client = getClientForEvent(event);
+  const client = getClientForEvent(event);
+  const slack = getSlackClientForEvent(event);
 
-    for (const project of event.projects) {
-      if (existingStandupIds.has(project.id)) {
-        DEBUG(`Skipping project ${project.id} — standup already exists`);
-        continue;
-      }
+  for (const project of event.projects) {
+    try {
+      await slack.conversations.invite({
+        channel: project.slackChannelId!,
+        users: STANDUP_USER,
+      });
+    } catch (ex) {}
 
-      if (!project.slackChannelId) {
-        DEBUG(`Skipping project ${project.id} — no Slack channel`);
-        continue;
-      }
+    DEBUG(project.students);
+    const users = project.students
+      .filter((s) => s.slackId)
+      .map((s) => ({ userId: s.slackId! }));
 
-      const users = project.students
-        .filter((s) => s.slackId)
-        .map((s) => ({ userId: s.slackId! }));
+    if (users.length === 0) {
+      DEBUG(`Skipping project ${project.id} — no eligible student Slack IDs`);
+      continue;
+    }
 
-      if (users.length === 0) {
-        DEBUG(`Skipping project ${project.id} — no eligible student Slack IDs`);
-        continue;
-      }
-
-      const body = {
+    try {
+      const result = await client.createStandup({
         ...DEFAULT_STANDUP,
         channel: project.slackChannelId,
         channelId: project.slackChannelId,
         users,
-      };
-
-      try {
-        const result = await client.createStandup(body);
-        if (result.standupId) {
-          await prisma.project.update({
-            where: { id: project.id },
-            data: { standupId: result.standupId },
-          });
-        }
-        DEBUG(`Created standup for project ${project.id} in channel ${project.slackChannelId}`);
-      } catch (ex) {
-        DEBUG(ex);
+      });
+      if (result.standupId) {
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { standupId: result.standupId },
+        });
       }
+      DEBUG(
+        `Created standup for project ${project.id} in channel ${project.slackChannelId}`,
+      );
+    } catch (ex) {
+      DEBUG(ex);
     }
   }
 }

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -39,6 +39,13 @@ export default async function createStandup({ auth }: Context): Promise<void> {
   if (!apiKey) throw new Error('STANDUP_API_KEY environment variable is not set');
 
   const prisma = Container.get(PrismaClient);
+
+  const existing = await prisma.project.findMany({
+    where: { event: { id: auth.eventId }, standupId: { not: null } },
+    select: { id: true },
+  });
+  const existingStandupIds = new Set(existing.map((p: { id: string }) => p.id));
+
   const events = await prisma.event.findMany({
     where: {
       id: auth.eventId,
@@ -52,6 +59,11 @@ export default async function createStandup({ auth }: Context): Promise<void> {
     const teamId = event.slackWorkspaceId;
 
     for (const project of event.projects) {
+      if (existingStandupIds.has(project.id)) {
+        DEBUG(`Skipping project ${project.id} — standup already exists`);
+        continue;
+      }
+
       if (!project.slackChannelId) {
         DEBUG(`Skipping project ${project.id} — no Slack channel`);
         continue;
@@ -87,6 +99,13 @@ export default async function createStandup({ auth }: Context): Promise<void> {
           const text = await res.text();
           DEBUG(`Failed for project ${project.id}: ${res.status} ${text}`);
         } else {
+          const data = await res.json() as { id?: string };
+          if (data.id) {
+            await prisma.project.update({
+              where: { id: project.id },
+              data: { standupId: data.id },
+            });
+          }
           DEBUG(`Created standup for project ${project.id} in channel ${project.slackChannelId}`);
         }
       } catch (ex) {

--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -12,7 +12,6 @@ import { makeDebug } from "../../utils";
 const DEBUG = makeDebug('activities:tasks:createStandup');
 
 const STANDUP_API_BASE = 'https://api.standup-and-prosper.com/v1';
-const EXCLUDED_SLACK_IDS = new Set(['U07ACCWHDSA']);
 
 const DEFAULT_STANDUP = {
   type: 'SLACK',
@@ -70,7 +69,7 @@ export default async function createStandup({ auth }: Context): Promise<void> {
       }
 
       const users = project.students
-        .filter((s) => s.slackId && !EXCLUDED_SLACK_IDS.has(s.slackId))
+        .filter((s) => s.slackId)
         .map((s) => ({ userId: s.slackId! }));
 
       if (users.length === 0) {

--- a/src/standupAndProsper/StandupAndProsper.ts
+++ b/src/standupAndProsper/StandupAndProsper.ts
@@ -69,6 +69,26 @@ export class StandupAndPropser {
     if (!Array.isArray(result.threads)) throw new Error(`Expected array, got ${JSON.stringify(result)}`);
     return result.threads;
   }
+
+  async post<T = object>(path: string, body: object): Promise<T> {
+    const result = await fetch(
+      `https://api.standup-and-prosper.com/v1/teams/${this.teamId}${path}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    return result.json();
+  }
+
+  async createStandup(options: object): Promise<Standup> {
+    return this.post<Standup>('/standups', options);
+  }
 }
 
 export function getClientForEvent(


### PR DESCRIPTION
- Adds a new admin activity task that creates per-project Slack standups via the Standup & Prosper API.
- When run, the task iterates over all matched projects in the event that have a Slack channel configured, filters for accepted students with Slack IDs, and creates a weekly standup for each project posted to that project's channel.