### PR TITLE
Add type field to DEFAULT_STANDUP in createStandup

### DIFF
--- a/src/activities/tasks/createStandup.ts
+++ b/src/activities/tasks/createStandup.ts
@@ -18,6 +18,7 @@ const DEBUG = makeDebug("activities:tasks:createStandup");
 const STANDUP_USER = "U026ZCTG0CB";
 
 const DEFAULT_STANDUP = {
+  type: "SLACK",
   admins: ["U024H3101", "U07ACCWHDSA"],
   days: ["Monday", "Wednesday", "Friday"],
   time: "20:00:00",


### PR DESCRIPTION
The type field being removed is the culprit for standups not being created by the automation created. Not sure how it was removed, but it should fix it.